### PR TITLE
edify: Fix AssertSomeBaseband

### DIFF
--- a/tools/releasetools/edify_generator.py
+++ b/tools/releasetools/edify_generator.py
@@ -160,7 +160,7 @@ class EdifyGenerator(object):
            ", ".join(["%s" % (b,) for b in basebands]) +
            '; this device has baseband " + getprop("ro.baseband") + ".");' +
            ");")
-    self.script.append(self._WordWrap(cmd))
+    self.script.append(self.WordWrap(cmd))
 
   def RunBackup(self, command):
     self.script.append(('run_program("/tmp/install/bin/backuptool.sh", "%s");' % command))


### PR DESCRIPTION
When 'Edify: Add AssertSomeBaseband' was cherry-picked to cafrebase,
it used ._WordWrap (doesn't exist now) instead of .WordWrap. Fix it.

Change-Id: I63fcabe1d12abe41c1501907685daa6ab5f8f4f1