### PR TITLE
ota_from_target_files: CalculateFingerprint when dump fingerprints

### DIFF
--- a/tools/releasetools/ota_from_target_files.py
+++ b/tools/releasetools/ota_from_target_files.py
@@ -1701,8 +1701,10 @@ else if get_stage("%(bcb_dev)s") != "3/3" then
 """ % bcb_dev)
 
   # Dump fingerprints
-  script.Print("Source: %s" % (source_fp,))
-  script.Print("Target: %s" % (target_fp,))
+  script.Print("Source: %s" % CalculateFingerprint(
+      oem_props, oem_dict, OPTIONS.source_info_dict))
+  script.Print("Target: %s" % CalculateFingerprint(
+      oem_props, oem_dict, OPTIONS.target_info_dict))
 
   script.Print("Verifying current system...")
 


### PR DESCRIPTION
This change fixed "UnboundLocalError: local variable 'source_fp' referenced before assignment" error.

Change-Id: I37aac562951b76258d95dbbfd9fac80c5ac978da