### PR TITLE
Squashed revert of TARGET_UNIFIED_DEVICE

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -264,7 +264,6 @@ endif
 			TARGET_CPU_ABI="$(TARGET_CPU_ABI)" \
 			TARGET_CPU_ABI2="$(TARGET_CPU_ABI2)" \
 			TARGET_AAPT_CHARACTERISTICS="$(TARGET_AAPT_CHARACTERISTICS)" \
-			TARGET_UNIFIED_DEVICE="$(TARGET_UNIFIED_DEVICE)" \
 			$(PRODUCT_BUILD_PROP_OVERRIDES) \
 	        bash $(BUILDINFO_SH) >> $@
 	$(hide) $(foreach file,$(system_prop_file), \
@@ -2141,7 +2140,6 @@ else
 	$(hide) vendor/cm/build/tools/getb64key.py $(DEFAULT_SYSTEM_DEV_CERTIFICATE).x509.pem > $(zip_root)/META/releasekey.txt
 endif
 	$(hide) echo "ota_override_device=$(OTA_SCRIPT_OVERRIDE_DEVICE)" >> $(zip_root)/META/misc_info.txt
-	$(hide) echo "ota_override_prop=$(OTA_SCRIPT_OVERRIDE_PROP)" >> $(zip_root)/META/misc_info.txt
 	@# Zip everything up, preserving symlinks and placing META/ files first to
 	@# help early validation of the .zip file while uploading it.
 	$(hide) (cd $(zip_root) && \
@@ -2206,13 +2204,6 @@ ifeq ($(TARGET_OTA_ASSERT_DEVICE),)
     OTA_SCRIPT_OVERRIDE_DEVICE := auto
 else
     OTA_SCRIPT_OVERRIDE_DEVICE := $(TARGET_OTA_ASSERT_DEVICE)
-endif
-
-ifneq ($(TARGET_UNIFIED_DEVICE),)
-    OTA_SCRIPT_OVERRIDE_PROP := true
-    ifeq ($(TARGET_OTA_ASSERT_DEVICE),)
-        OTA_SCRIPT_OVERRIDE_DEVICE := $(TARGET_DEVICE)
-    endif
 endif
 
 ifneq ($(BLOCK_BASED_OTA),false)

--- a/tools/buildinfo.sh
+++ b/tools/buildinfo.sh
@@ -26,8 +26,10 @@ fi
 if [ -n "$AB_OTA_UPDATER" ] ; then
   echo "ro.build.ab_update=$AB_OTA_UPDATER"
 fi
+echo "ro.product.model=$PRODUCT_MODEL"
 echo "ro.product.brand=$PRODUCT_BRAND"
 echo "ro.product.name=$PRODUCT_NAME"
+echo "ro.product.device=$TARGET_DEVICE"
 echo "ro.product.board=$TARGET_BOOTLOADER_BOARD_NAME"
 
 # These values are deprecated, use "ro.product.cpu.abilist"
@@ -49,17 +51,14 @@ fi
 echo "ro.wifi.channels=$PRODUCT_DEFAULT_WIFI_CHANNELS"
 echo "ro.board.platform=$TARGET_BOARD_PLATFORM"
 
-if [ "$TARGET_UNIFIED_DEVICE" == "" ] ; then
-  echo "# ro.build.product is obsolete; use ro.product.device"
-  echo "ro.build.product=$TARGET_DEVICE"
-  echo "ro.product.model=$PRODUCT_MODEL"
-  echo "ro.product.device=$TARGET_DEVICE"
-  echo "# Do not try to parse description, fingerprint, or thumbprint"
-  echo "ro.build.description=$PRIVATE_BUILD_DESC"
-  echo "ro.build.fingerprint=$BUILD_FINGERPRINT"
-  if [ -n "$BUILD_THUMBPRINT" ] ; then
-    echo "ro.build.thumbprint=$BUILD_THUMBPRINT"
-  fi
+echo "# ro.build.product is obsolete; use ro.product.device"
+echo "ro.build.product=$TARGET_DEVICE"
+
+echo "# Do not try to parse description, fingerprint, or thumbprint"
+echo "ro.build.description=$PRIVATE_BUILD_DESC"
+echo "ro.build.fingerprint=$BUILD_FINGERPRINT"
+if [ -n "$BUILD_THUMBPRINT" ] ; then
+  echo "ro.build.thumbprint=$BUILD_THUMBPRINT"
 fi
 echo "ro.build.characteristics=$TARGET_AAPT_CHARACTERISTICS"
 


### PR DESCRIPTION
* vendor init can be used to achieve everything done here

Revert "core: Fix unified trees with no TARGET_OTA_ASSERT_DEVICE"
This reverts commit e44fa493f87d74c20b4276ca7504bc601847d01f.

Revert "releasetools: don't attempt to read fingerprint on unified devices"
This reverts commit 787a0aa7d8787c13bf78559ae4a05650ed46da76.

Revert "buildinfo: only set ro.build.product on non-unified devices"
This reverts commit 22c034b8a7c51c713dfb2a75c6e4e20941428cad.

Revert "ota_from_target_files: Remove device dependent arguments"
This reverts commit 7c93b441bcf65a8630f8f4bb8df9537f686ea797.

Revert "Fix ro.build.product not found by ota_from_target_files in some cases"
This reverts commit 0ca5495057a6d15f6049993896c34e13cd4dd467.

Revert "Allow devices to specify certain ro. props via TARGET_UNIFIED_DEVICE"
This reverts commit 8182bc29ffc498033e25ef10f3f8499ebfe25a7e.

ota_from_target_files: Remove device dependent arguments
These device-specific arguments are defined at build time and are
necessary to generate the zip correctly. Don't use command line
arguments to specify them, but write all the needed information
in misc_info.txt when the target-files zip is generated.
ota_from_target_files will then read misc_info.txt and set
everything automatically.
Original Change-Id: Ibdbca575b76eb07b53fccfcea52a351c7e333f91
[mikeioannina]: Reapply after TARGET_UNIFIED_DEVICE removal

Change-Id: I5cb8f074c893c0e46edf507f6256cd747239d07f