### PR TITLE
Move away from USE_HOST flag and introduce $BINARY_EXEC

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -573,8 +573,8 @@ ZIPTIME := $(prebuilt_build_tools_bin)/ziptime
 # Generic tools.
 JACK := $(HOST_OUT_EXECUTABLES)/jack
 
-ifeq ($(USE_HOST_FLEX),yes)
-LEX := flex
+ifneq ($(FLEX_EXEC),)
+LEX := $(FLEX_EXEC)
 else
 LEX := prebuilts/misc/$(BUILD_OS)-$(HOST_PREBUILT_ARCH)/flex/flex-2.5.39
 endif
@@ -583,8 +583,8 @@ endif
 # To run bison from elsewhere you need to set up enviromental variable
 # BISON_PKGDATADIR.
 BISON_PKGDATADIR := $(PWD)/external/bison/data
-ifeq ($(USE_HOST_BISON),yes)
-BISON := bison
+ifneq ($(BISON_EXEC),)
+BISON := $(BISON_EXEC)
 else
 BISON := prebuilts/misc/$(BUILD_OS)-$(HOST_PREBUILT_ARCH)/bison/bison
 endif


### PR DESCRIPTION
* The prebuilt flex binary crashes due changes in newer glibc versions,
  and the prebuilt bison binary doesn't work on newer Darwin versions.

* While this works for most of the usecases,
  you shouldn't pollute your path with an older version of flex or bison,
  and at the same time you shouldn't use the binary provided
  by the host for compatibility reasons
 -> Add a flag to allow the user to provide its own flex and bison binary,
    that should match the version provided by AOSP.

Usage: Add `export FLEX_EXEC=$path_to_flex` in your .bashrc/.zshrc
Example: `export FLEX_EXEC=$HOME/android/flex-2.5.39`

Change-Id: I75f98372a221b48636f870a5b7984f0a779fa29d