### PR TITLE
build: Clean up makefile hook inclusions

### DIFF
--- a/core/config.mk
+++ b/core/config.mk
@@ -983,14 +983,6 @@ $(eval include device/lineage/sepolicy/common/sepolicy.mk)
 # Include any vendor specific config.mk file
 -include $(TOPDIR)vendor/*/build/core/config.mk
 
-# Include any vendor specific apicheck.mk file
--include $(TOPDIR)vendor/*/build/core/apicheck.mk
-
-# Rules for QCOM targets
--include $(TOPDIR)vendor/lineage/build/core/qcom_target.mk
-
-# Rules for MTK targets
--include $(TOPDIR)vendor/lineage/build/core/mtk_target.mk
 endif
 
 include $(BUILD_SYSTEM)/dumpvar.mk

--- a/core/main.mk
+++ b/core/main.mk
@@ -327,7 +327,7 @@ ADDITIONAL_BUILD_PROPERTIES += dalvik.vm.stack-trace-dir=/data/anr
 
 # ------------------------------------------------------------
 # Include vendor specific additions to build properties
--include vendor/lineage/config/main.mk
+-include vendor/lineage/build/core/main.mk
 
 # ------------------------------------------------------------
 # Define a function that, given a list of module tags, returns


### PR DESCRIPTION
* Include MTK/QCOM rules directly from
  vendor/lineage/build/core/config.mk hook, since that is what it is
  there for.
* Remove apicheck.mk hook, this is unused, and if it turns out to be
  needed again, it can be included by the config.mk hook mentioned above.
* Place main.mk hook into vendor/lineage/build/core/main.mk with the
  rest of the make build system hooks.

Change-Id: I51bda9f5d35a63113d6eab98e06da8919ba46480