### PR TITLE
core: Remove deprecated kernel header dependency path warning

### DIFF
--- a/core/binary.mk
+++ b/core/binary.mk
@@ -37,7 +37,6 @@ my_soong_problems :=
 # However, there are many instances of the old style dependencies in the
 # source tree.  Fix them up and warn the user.
 ifneq (,$(findstring $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr,$(LOCAL_ADDITIONAL_DEPENDENCIES)))
-  $(warning $(LOCAL_MODULE) uses deprecated kernel header dependency path.)
   LOCAL_ADDITIONAL_DEPENDENCIES := $(patsubst $(TARGET_OUT_INTERMEDIATES)/KERNEL_OBJ/usr,INSTALLED_KERNEL_HEADERS,$(LOCAL_ADDITIONAL_DEPENDENCIES))
 endif
 


### PR DESCRIPTION
Change-Id: I68b44fd1e868a3326a6ab1a7e5fe42b8eeecd1c1