### PR TITLE
core_base: Remove libnfc_ndef from PRODUCT_PACKAGES

### DIFF
--- a/target/product/core_base.mk
+++ b/target/product/core_base.mk
@@ -29,7 +29,6 @@ PRODUCT_PACKAGES += \
     libfilterpack_imageproc \
     libgabi++ \
     libmdnssd \
-    libnfc_ndef \
     libpowermanager \
     libspeexresampler \
     libstagefright_soft_aacdec \


### PR DESCRIPTION
 * This was a dependency of legacy NXP NFC stack, deprecated long ago.
   The devices that are still using this stack are explicitly building
   libnfc, which in turn has libnfc_ndef as shared lib.

Change-Id: Id3b859cdea00452f7d1ee21455e08fe342649a1e