### PR TITLE
Quote message in echo-error/echo-warning macros

### DIFF
--- a/core/definitions.mk
+++ b/core/definitions.mk
@@ -856,13 +856,13 @@ ESC_RESET := \033[0m
 # $(1): path (and optionally line) information
 # $(2): message to print
 define echo-warning
-echo -e "$(ESC_BOLD)$(1): $(ESC_WARNING)warning:$(ESC_RESET)$(ESC_BOLD)" $(2) "$(ESC_RESET)" >&2
+echo -e "$(ESC_BOLD)$(1): $(ESC_WARNING)warning:$(ESC_RESET)$(ESC_BOLD)" '$(subst ','\'',$(2))'  "$(ESC_RESET)" >&2
 endef
 
 # $(1): path (and optionally line) information
 # $(2): message to print
 define echo-error
-echo -e "$(ESC_BOLD)$(1): $(ESC_ERROR)error:$(ESC_RESET)$(ESC_BOLD)" $(2) "$(ESC_RESET)" >&2
+echo -e "$(ESC_BOLD)$(1): $(ESC_ERROR)error:$(ESC_RESET)$(ESC_BOLD)" '$(subst ','\'',$(2))'  "$(ESC_RESET)" >&2
 endef
 
 # $(1): message to print


### PR DESCRIPTION
Makes pretty-error and pretty-warning behave more like $(error) and
$(warning), where you don't need to do things like quote parentheses.

Bug: 118833208
Test: trigger the private_apis && sdk set error in sdk_check.mk,
      which no longer produces bash syntax errors

Change-Id: I766ff98ad4e652f59dbef9dd5654f1cd10a2d038