### PR TITLE
sign_target_apks: Add networkstack to default key_map

### DIFF
--- a/tools/releasetools/sign_target_files_apks.py
+++ b/tools/releasetools/sign_target_files_apks.py
@@ -917,6 +917,7 @@ def BuildKeyMap(misc_info, key_mapping_options):
           devkeydir + "/media":    d + "/media",
           devkeydir + "/shared":   d + "/shared",
           devkeydir + "/platform": d + "/platform",
+          devkeydir + "/networkstack": d + "/networkstack",
           })
     else:
       OPTIONS.key_map[s] = d


### PR DESCRIPTION
Test: run cts -m CtsSecurityTestCases -t \
	android.security.cts.PackageSignatureTest#testPackageSignatures
Bug: 145955635
Change-Id: I1a1498562e2b5983010cb98e3edcd03ceb2cce19
Signed-off-by: Oleh Cherpak <oleh.cherpak@globallogic.com>