### PR TITLE
Do not remove RRO resources

### DIFF
--- a/core/build_rro_package.mk
+++ b/core/build_rro_package.mk
@@ -32,6 +32,12 @@ else
   LOCAL_MODULE_PATH := $(partition)/overlay/$(LOCAL_RRO_THEME)
 endif
 
+# Do not remove resources without default values nor dedupe resource
+# configurations with the same value
+LOCAL_AAPT_FLAGS += \
+    --no-resource-deduping \
+    --no-resource-removal
+
 partition :=
 
 include $(BUILD_SYSTEM)/package.mk


### PR DESCRIPTION
Resource configs should not be deduped when building RROs since it
would be impossible to override some resource configs with the same
value as the default config. Also, aapt2 removes resources that do not
have default configurations. If an overlay attempts to overlay a
non-default configuration without overlaying the default, the resource
will be removed and the value will not be overlaid at all.

Bug: 146227008
Test: m-j
Change-Id: I1465b599cbf7f464d1b5b75a87e7dafa2cf734b0