### PR TITLE
Introduce build variable `OVERRIDE_TARGET_FLATTEN_APEX`.

### DIFF
--- a/core/board_config.mk
+++ b/core/board_config.mk
@@ -508,8 +508,16 @@ endif
 # APEXes are by default flattened, i.e. non-updatable.
 # It can be unflattened (and updatable) by inheriting from
 # updatable_apex.mk
-ifeq (,$(TARGET_FLATTEN_APEX))
-TARGET_FLATTEN_APEX := true
+#
+# APEX flattening can also be forcibly enabled (resp. disabled) by
+# setting OVERRIDE_TARGET_FLATTEN_APEX to true (resp. false), e.g. by
+# setting the OVERRIDE_TARGET_FLATTEN_APEX environment variable.
+ifdef OVERRIDE_TARGET_FLATTEN_APEX
+  TARGET_FLATTEN_APEX := $(OVERRIDE_TARGET_FLATTEN_APEX)
+else
+  ifeq (,$(TARGET_FLATTEN_APEX))
+    TARGET_FLATTEN_APEX := true
+  endif
 endif
 
 ifeq (,$(TARGET_BUILD_APPS))

--- a/target/product/updatable_apex.mk
+++ b/target/product/updatable_apex.mk
@@ -16,6 +16,8 @@
 
 # Inherit this when the target needs to support updating APEXes
 
-PRODUCT_PROPERTY_OVERRIDES := ro.apex.updatable=true
-PRODUCT_PACKAGES := com.android.apex.cts.shim.v1_prebuilt
-TARGET_FLATTEN_APEX := false
+ifneq ($(OVERRIDE_TARGET_FLATTEN_APEX),true)
+  PRODUCT_PROPERTY_OVERRIDES := ro.apex.updatable=true
+  PRODUCT_PACKAGES := com.android.apex.cts.shim.v1_prebuilt
+  TARGET_FLATTEN_APEX := false
+endif


### PR DESCRIPTION
When `OVERRIDE_TARGET_FLATTEN_APEX` is defined (e.g. set in the
environment), `TARGET_FLATTEN_APEX` is forcibly assigned its value.

This is useful to enable/disable APEX flattening from the command
line (thus ignoring the product's default configuration), for testing
purposes.

Note: Previously it was possible to set `TARGET_FLATTEN_APEX` directly
and have the same effect, but recent changes in the build
configuration now prevent that option.

Test: Check that:
        export OVERRIDE_TARGET_FLATTEN_APEX=true \
          && . ./build/envsetup.sh \
          && lunch aosp_walleye-userdebug \
          && export OVERRIDE_TARGET_FLATTEN_APEX=true \
          && build/soong/soong_ui.bash --dumpvar-mode TARGET_FLATTEN_APEX
      returns:
        true
Bug: 121117762

Change-Id: Ib9ccae38430340de38e4758b4f55df2c65ea60d5