### PR TITLE
build: Disable backuptool on user instead of GMS builds

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -4280,7 +4280,7 @@ else
     OTA_SCRIPT_OVERRIDE_DEVICE := $(TARGET_OTA_ASSERT_DEVICE)
 endif
 
-ifeq ($(WITH_GMS),true)
+ifeq ($(TARGET_BUILD_VARIANT),user)
     $(INTERNAL_OTA_PACKAGE_TARGET): backuptool := false
 else
 ifneq ($(LINEAGE_BUILD),)


### PR DESCRIPTION
* Backuptool is not exclusively used for GApps but
  also used by other things (i.e. Magisk), hence
  it shouldn't be disabled on all GMS builds.

Change-Id: Ia95c6fed21d7bed5e2e0610aa94264edc1d02c80