### PR TITLE
Avoid adding VINTF manifest fragment more than once.

### DIFF
--- a/core/base_rules.mk
+++ b/core/base_rules.mk
@@ -523,11 +523,11 @@ my_vintf_installed := $(foreach xml,$(my_vintf_pairs),$(call word-colon,2,$(xml)
 
 # Only set up copy rules once, even if another arch variant shares it
 my_vintf_new_pairs := $(filter-out $(ALL_VINTF_MANIFEST_FRAGMENTS_LIST),$(my_vintf_pairs))
-my_vintf_new_installed := $(call copy-many-vintf-manifest-files-checked,$(my_vintf_pairs))
+my_vintf_new_installed := $(call copy-many-vintf-manifest-files-checked,$(my_vintf_new_pairs))
 
 ALL_VINTF_MANIFEST_FRAGMENTS_LIST += $(my_vintf_new_pairs)
 
-$(my_all_targets) : $(my_vintf_installed)
+$(my_all_targets) : $(my_vintf_new_installed)
 endif # LOCAL_VINTF_FRAGMENTS
 endif # !LOCAL_IS_HOST_MODULE
 endif # !LOCAL_UNINSTALLABLE_MODULE


### PR DESCRIPTION
In the case of building a multilib library that defines LOCAL_VINTF_FRAGMENTS,
the previous code would create duplicate rules for the fragment. This change
uses the my_vintf_new_installed variable (which may be empty) to avoid the
duplication.

Bug: 139268165
Test: Verify that build warnings are gone, yet VINTF fragment still installed.
Change-Id: I579ec650019a29a6a105118ad5e5ae9376e8d9bc
(cherry picked from commit 6733381fceb44fe074e3586c7a94705c4d49a509)